### PR TITLE
Skip permission test for root and Windows

### DIFF
--- a/cmd/basic/main_test.go
+++ b/cmd/basic/main_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -48,6 +49,10 @@ func TestReadBasicFileNotFound(t *testing.T) {
 }
 
 func TestReadBasicFilePermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("permission tests not reliable on this platform or when running as root")
+	}
+
 	// Create a file with no read permissions
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "noperm.bas")


### PR DESCRIPTION
## Summary
- Skip TestReadBasicFilePermissionDenied when running as root or on Windows so suite passes reliably

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6974ee7fc83308dca174fca12f2cd